### PR TITLE
Document 1.0.13, 1.1.0, and 2.0.0 in changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,26 @@
 
+2.0.0 / 2026-04-06
+==================
+
+* Full rewrite as TypeScript Custom Elements v1
+* Switch build tooling to Vite, ship ESM build and `.d.ts` type declarations
+* Bundle `fen-chess-board@3` — zero runtime dependencies in `dist`
+* Drop `webcomponents.js` polyfill, HTML Imports and Bower — modern browsers only
+* Add vitest + happy-dom test suite and GitHub Actions Pages deploy
+
+1.1.0 / 2016-09-23
+==================
+
+* Add MutationObserver to track FEN changes via `innerHTML`
+
+1.0.13 / 2016-09-15
+===================
+
+* Fix second shadowRoot being created on re-render (#7)
+* `clearBoard` now actually clears the board
+* Move `fen-chess-board` to a separate package
+* Dependency bumps and switch to airbnb lint preset
+
 1.0.3 / 2016-03-13
 ==================
 


### PR DESCRIPTION
## Summary

The changelog had been stale since `1.0.3 / 2016-03-13`. This PR adds entries for the three releases that shipped afterwards:

- **1.0.13** (2016-09-15) — shadowRoot fix (#7), `clearBoard` fix, `fen-chess-board` split out
- **1.1.0** (2016-09-23) — MutationObserver on innerHTML FEN
- **2.0.0** (2026-04-06) — full TypeScript rewrite, Custom Elements v1, Vite build, ESM + `.d.ts`, drops webcomponents.js polyfill

Docs-only; no source or config changes.