### PR TITLE
Fix shadow root creation on element reconnect

### DIFF
--- a/src/chess-board.test.ts
+++ b/src/chess-board.test.ts
@@ -254,4 +254,21 @@ describe("chess-board", () => {
       expect(table.rows[0].cells[0].firstElementChild).toBe(a8piece);
     });
   });
+
+  describe("reconnection", () => {
+    it("can be detached and re-inserted without error", () => {
+      const el = createElement(START_FEN);
+      expect(getPieceAt(el, 0, 0)).toBe("r");
+
+      expect(() => {
+        document.body.removeChild(el);
+        document.body.appendChild(el);
+      }).not.toThrow();
+
+      // Board still renders the correct position after reconnect
+      expect(getPieceAt(el, 0, 0)).toBe("r");
+      expect(getPieceAt(el, 0, 4)).toBe("k");
+      expect(getPieceAt(el, 7, 4)).toBe("K");
+    });
+  });
 });

--- a/src/chess-board.ts
+++ b/src/chess-board.ts
@@ -187,21 +187,25 @@ export class ChessBoardElement extends HTMLElement {
   constructor() {
     super();
     this._board = new FENBoard();
-  }
-
-  connectedCallback(): void {
     const shadow = this.attachShadow({ mode: "open" });
     shadow.innerHTML = buildBoardHTML();
     this._table = shadow.querySelector(".chess-board") as HTMLTableElement;
+  }
 
-    // Initialize from innerHTML if present
+  connectedCallback(): void {
+    // Initialize from innerHTML if present. Parser-parsed elements get
+    // children after connectedCallback fires, so textContent may still be
+    // empty at construction time — this is why we read it here and also
+    // why the MutationObserver exists.
     const initialFen = this.textContent?.trim();
     if (initialFen) {
       this._board.fen = initialFen;
     }
     this._renderBoard();
 
-    // Watch for innerHTML FEN changes
+    // connectedCallback may fire multiple times if the element is moved.
+    // Tear down any previous observer before creating a new one.
+    this._observer?.disconnect();
     this._observer = new MutationObserver(() => {
       const newFen = this.textContent?.trim();
       if (newFen) {
@@ -219,7 +223,6 @@ export class ChessBoardElement extends HTMLElement {
   disconnectedCallback(): void {
     this._observer?.disconnect();
     this._observer = null;
-    this._table = null!;
   }
 
   attributeChangedCallback(
@@ -227,7 +230,7 @@ export class ChessBoardElement extends HTMLElement {
     _oldValue: string | null,
     _newValue: string | null,
   ): void {
-    if (name === "unicode" && this._table) {
+    if (name === "unicode") {
       this._renderBoard();
     }
   }


### PR DESCRIPTION
## Bug

`connectedCallback()` called `this.attachShadow({ mode: "open" })` every time the element was connected. If a `<chess-board>` element was detached and re-inserted (e.g. moved within the DOM), the second call threw:

> Shadow root cannot be created on a host which already hosts a shadow root

`disconnectedCallback()` also nulled `_table`, which would surface as a confusing failure if any method touched it after disconnect.

## Fix

- Move shadow root creation, HTML template build, and `_table` assignment into the **constructor**. Autonomous custom elements can safely build shadow DOM in the constructor since they don't touch attributes or children.
- Keep the initial-FEN read from `textContent` and the `MutationObserver` setup in `connectedCallback` — parser-parsed elements get their children after `connectedCallback` fires, which is also why the observer exists.
- In `disconnectedCallback`, only disconnect the observer. The `_table` reference is left intact so reconnect works.
- Tear down any existing observer before creating a new one in `connectedCallback`, since that hook may run multiple times if the element is moved.
- Drop the now-redundant `_table` guard in `attributeChangedCallback`.

## Test

Added a `reconnection` test that creates the element with a FEN, detaches it with `removeChild`, re-attaches it with `appendChild`, asserts no error is thrown, and verifies the board still renders the correct position (`getPieceAt(el, 0, 0) === "r"`).

All existing tests still pass; build succeeds.