### PR TITLE
Register chess-board on HTMLElementTagNameMap

### DIFF
--- a/src/chess-board.test.ts
+++ b/src/chess-board.test.ts
@@ -46,6 +46,11 @@ describe("chess-board", () => {
       const el = createElement();
       expect(el).toBeInstanceOf(HTMLElement);
       expect(el.shadowRoot).not.toBeNull();
+      // Type-level assertion: HTMLElementTagNameMap augmentation should make
+      // document.querySelector("chess-board") infer as ChessBoardElement | null.
+      const typed: ChessBoardElement | null =
+        document.querySelector("chess-board");
+      expect(typed).not.toBeNull();
     });
 
     it("initializes with FEN from textContent", () => {

--- a/src/chess-board.ts
+++ b/src/chess-board.ts
@@ -290,3 +290,9 @@ export class ChessBoardElement extends HTMLElement {
 }
 
 customElements.define("chess-board", ChessBoardElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "chess-board": ChessBoardElement;
+  }
+}


### PR DESCRIPTION
## Summary

Add a `declare global` augmentation for `HTMLElementTagNameMap` so consumers get proper type inference for the custom element.

Previously, calls like `document.querySelector("chess-board")` returned `Element | null` and `document.createElement("chess-board")` returned `HTMLElement`, forcing consumers to cast manually to `ChessBoardElement`. With this augmentation, TypeScript infers `ChessBoardElement | null` and `ChessBoardElement` respectively - no casts needed.

## Changes

- `src/chess-board.ts`: Add `declare global` block registering `"chess-board": ChessBoardElement` on `HTMLElementTagNameMap` directly after `customElements.define(...)`.
- `src/chess-board.test.ts`: Small type-level assertion in the existing "registers as a custom element" test to prove inference works at compile time.

## Test plan

- [x] `pnpm build` compiles cleanly and the emitted `dist/chess-board.d.ts` contains the `declare global` augmentation.
- [x] `pnpm exec tsc --noEmit` passes (full project type-check including tests).
- [x] `pnpm test` - all 20 existing tests pass.