### PR TITLE
Exclude test files from TypeScript build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,6 @@
     "esModuleInterop": true,
     "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["**/*.test.ts"]
 }


### PR DESCRIPTION
## Problem

`tsconfig.json` had `"include": ["src"]` with no `"exclude"`, so `tsc --emitDeclarationOnly` (run from `pnpm build`) emitted `dist/chess-board.test.d.ts` alongside the real `dist/chess-board.d.ts`. The `"files": ["dist", "!dist/**/*.test.*"]` negation in `package.json` masked the leak from npm publishes, but the underlying config was still wrong and the stray declaration file was still generated on disk.

## Fix

Add `"exclude": ["**/*.test.ts"]` to `tsconfig.json` so test files are omitted from the TypeScript compile entirely.

## Verification

- `rm -rf dist && pnpm build` now produces only `dist/chess-board.js` and `dist/chess-board.d.ts` (no `chess-board.test.d.ts`).
- `pnpm test` still passes (20/20), since vitest has its own configuration and is unaffected.