### PR TITLE
Expand the unreleased changelog entry

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,29 +2,86 @@
 Unreleased
 ==========
 
-* Malformed FEN in the element's text content is now reported with
-  `console.warn` and ignored, keeping the current position. Previously
-  `fen-chess-board` accepted anything; version 4 validates and throws, which
-  would have thrown out of `connectedCallback` and left the element blank.
-  The `fen` setter and `move()` still throw on bad input.
-* Skip `customElements.define` when `<chess-board>` is already registered, so
-  loading the module twice (two bundles, HMR) no longer throws
-* Parse each SVG piece once and clone it, instead of re-parsing the markup on
-  every render
-* Replace the deprecated `cellpadding` / `cellspacing` table attributes with CSS
-* Ship only the library declarations: `dist/chess-board.test.d.ts` is no
-  longer generated or published
-* Bundle `fen-chess-board@4`
-* Toolchain: TypeScript 7, Vite 8, Vitest 5, happy-dom 20, pnpm 12 with
-  supply-chain policies (`minimumReleaseAge`, `trustPolicy`,
-  `blockExoticSubdeps`, `strictDepBuilds`)
-* CI: pin every action to a commit SHA, least-privilege permissions,
-  `persist-credentials: false`, concurrency limits, Node 22/24 matrix,
-  dependency review, zizmor audit workflow, Dependabot for actions
-* Release: stage the package with `pnpm stage publish` over npm trusted
-  publishing (OIDC) with provenance; a maintainer promotes it with
-  `pnpm stage approve`
-* Preview deploys of the demo site to Cloudflare Pages for every pull request
+**Behaviour changes for users of the element**
+
+* Invalid input now throws instead of quietly producing a broken board. This
+  comes from the bundled `fen-chess-board@4`, which validates everything it is
+  given:
+  * `fen = ...` rejects malformed piece placement: more than eight ranks, a
+    rank with more than eight squares, or the digits `0` and `9`. The board is
+    left unchanged. Version 3 silently truncated or dropped such input.
+  * `piece()`, `put()`, `clear()` and `move()` throw `Invalid square` for
+    anything that is not `a1`–`h8`. Version 3 crashed with a `TypeError` or
+    corrupted the board.
+  * `put()` throws `Invalid piece` unless the piece is a single character that
+    is not FEN syntax (digits, `/`, space). Version 3 accepted `"QQ"` and
+    produced FEN nobody can parse.
+  * Anything after the first space in a FEN string (active colour, castling,
+    move counters) is still ignored, as before.
+* Malformed FEN in the element's **text content** is reported with
+  `console.warn` and ignored, and the board keeps its current position. Without
+  this, the validation above would have thrown out of `connectedCallback` or
+  the `MutationObserver` and left the element blank.
+* `move(square, square)` no longer clears the piece; moving onto the same
+  square is a no-op.
+* The published bundle targets Vite's `baseline-widely-available` browsers
+  (roughly Chrome/Edge 107, Firefox 104, Safari 16 and newer) and uses
+  `Object.hasOwn`. Version 2.0 targeted Chrome 87, Firefox 78 and Safari 14.
+
+**Fixed**
+
+* Importing the module twice (two bundles, HMR) no longer throws from
+  `customElements.define`; registration is skipped when `<chess-board>` is
+  already defined.
+* `dist/chess-board.test.d.ts` is no longer generated or published; the
+  package ships only the library declarations.
+
+**Changed**
+
+* Each SVG piece is parsed once into a `<template>` and cloned on render,
+  instead of re-parsing the markup for every changed square.
+* The deprecated `cellpadding` / `cellspacing` table attributes are replaced by
+  `border-spacing: 0`; rendering is unchanged.
+* `dist/chess-board.js.map` is shipped alongside the bundle.
+* `package.json` is exported as `./package.json`.
+* The `Rank` type is derived from the rank tuple like `File` already was; the
+  resulting union is identical.
+
+**Development**
+
+* Toolchain: TypeScript 7, Vite 8, Vitest 5, happy-dom 20, pnpm 12. Node 22.12
+  or newer is required to work on the repository (consumers are unaffected).
+* `tsconfig.json` is stricter (`ES2022`, `noUncheckedIndexedAccess`,
+  `verbatimModuleSyntax`, `isolatedModules`); `tsconfig.build.json` excludes
+  tests from declaration emit; new `pnpm typecheck` script.
+* pnpm settings moved from `package.json` to `pnpm-workspace.yaml` with
+  supply-chain policies: `minimumReleaseAge` (24 h, `fen-chess-board`
+  excluded), `trustPolicy: no-downgrade`, `blockExoticSubdeps`,
+  `strictDepBuilds`. The `esbuild` build allow-list is gone; nothing in the
+  tree needs build scripts any more.
+* Tests rewritten with helpers; new coverage for the text-content path,
+  invalid FEN through both the setter and markup, attribute toggling in both
+  directions, observer teardown on disconnect and element registration
+  (21 → 27 tests).
+* CI: every action pinned to a commit SHA, `permissions: {}` with documented
+  job-level grants, `persist-credentials: false`, concurrency groups,
+  timeouts, Node 22/24 matrix, typecheck step, dependency review on pull
+  requests. `pnpm/setup` replaces `pnpm/action-setup` + `actions/setup-node`.
+* New zizmor workflow audits the workflows themselves (pedantic persona,
+  SARIF to code scanning, weekly schedule). Dependabot keeps the pinned
+  actions and the wrangler lockfile current with a 7-day cooldown; the
+  library's own dependencies are bumped by hand because Dependabot does not
+  support pnpm 12.
+* Release: the Publish workflow checks the tag against `package.json`, runs
+  typecheck/test/build, then stages the package with `pnpm stage publish`
+  over npm trusted publishing (OIDC) with provenance. A maintainer promotes
+  it with `pnpm stage approve`. No npm token and no dependency cache in the
+  release job.
+* Every pull request from a branch in this repository gets a Cloudflare Pages
+  preview of the demo site, posted as a PR comment. wrangler is pinned by
+  `.github/cloudflare/package-lock.json`, separate from the library's lockfile.
+* Documentation: readme sections for development, preview deploys and the
+  staged release flow; changelog entries backfilled for 2.0.2 and 2.0.3.
 
 2.0.3 / 2026-04-14
 ==================

--- a/readme.md
+++ b/readme.md
@@ -75,7 +75,8 @@ const currentFen = board.fen;
 ## Methods
 
 All methods operate on an already-mounted element. Grab it with
-`document.querySelector` — do not use `new`:
+`document.querySelector` — do not use `new`. Squares must be `a1`–`h8` and
+pieces a single character; anything else throws and leaves the board unchanged.
 
 ```js
 const board = document.querySelector("chess-board");


### PR DESCRIPTION
## Summary

The Unreleased entry written in #16 and #17 listed what changed in the repository but not what a user of `<chess-board>` will notice. This rewrites it into four groups and fills the gaps.

**Behaviour changes for users of the element** (new section)

- The stricter input validation inherited from `fen-chess-board@4`, with the version 3 behaviour each case replaces, verified by running both versions side by side:
  - `fen = ...` throws on more than eight ranks, a rank longer than eight squares, or the digits `0`/`9`; the board is left unchanged. v3 silently truncated or dropped such input.
  - `piece()`, `put()`, `clear()`, `move()` throw `Invalid square` outside `a1`–`h8`. v3 crashed with a `TypeError` or corrupted the board.
  - `put()` throws `Invalid piece` for anything that is not a single non-FEN-syntax character. v3 accepted `"QQ"` and produced unparseable FEN.
- `move(square, square)` is now a no-op instead of clearing the piece.
- Malformed FEN in text content: `console.warn` and keep the current position (already listed, moved here).
- The published bundle now targets Vite 8's `baseline-widely-available` browsers (roughly Chrome/Edge 107, Firefox 104, Safari 16) and uses `Object.hasOwn`; 2.0 targeted Chrome 87 / Firefox 78 / Safari 14.

**Fixed / Changed**: the double-registration guard, dropped test declarations, SVG template caching, `border-spacing` replacing deprecated attributes, plus the previously unlisted shipped sourcemap, `./package.json` export and derived `Rank` type.

**Development**: toolchain, stricter tsconfig, pnpm policies (and the removed `esbuild` allow-list), test coverage, CI hardening, zizmor, Dependabot scope and why the library's deps are excluded, staged release flow, preview deploys, backfilled 2.0.2/2.0.3 entries.

The readme Methods section now states the square and piece validation in one sentence, since it documents the API these rules apply to.

## Suggested version: 2.1.0

- Nothing in the intended API changed: same attributes, properties, methods and exported types.
- The new throws only affect inputs that were never valid and previously produced a corrupt board or a `TypeError`. Under semver that is a bug fix, not a breaking change, although anyone feeding untrusted FEN to the `fen` setter without a `try`/`catch` will now see exceptions instead of garbage.
- There are additive changes (sourcemap, `./package.json` export, double-import safety), which is what makes this a minor rather than a patch.
- The one argument for 3.0.0 is the raised browser baseline from Vite 8's default target. 2.0.0 already declared "modern browsers only" and Chrome 107 / Safari 16 are from late 2022, so I would not cut a major for it. If you treat browser support as part of the public contract, make it 3.0.0 and this changelog entry already states the change.

Recommendation: release as **2.1.0**. Rename the `Unreleased` heading to `2.1.0 / <date>` when tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChaqSMq3tG8bvWgpJBmdGC

---
_Generated by [Claude Code](https://claude.ai/code/session_01ChaqSMq3tG8bvWgpJBmdGC)_