### PR TITLE
Publish plain tsc output instead of a Vite bundle

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,11 +8,11 @@ Unreleased
   `dist/chess-board.js` is the readable ES2022 output of `src/chess-board.ts`
   (which ships in the package, so source maps and declaration maps resolve),
   and `fen-chess-board` is a regular runtime dependency rather than being
-  inlined. Anything that goes through a bundler or an ESM CDN such as esm.sh
-  keeps working unchanged. Loading `dist/chess-board.js` straight from a
-  `<script type="module">` tag with no bundler breaks, because the file now
-  imports the bare specifier `fen-chess-board`; add an import map for it or
-  load the package through an ESM CDN. See "Without a bundler" in the readme.
+  inlined. Anything that goes through a bundler keeps working unchanged.
+  Loading `dist/chess-board.js` straight from a `<script type="module">` tag
+  with no bundler breaks, because the file now imports the bare specifier
+  `fen-chess-board`; add an import map that points it at a copy of that
+  package. See "Without a bundler" in the readme.
 
 **Behaviour changes for users of the element**
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,18 @@
 Unreleased
 ==========
 
+**Breaking**
+
+* The package is now plain compiled TypeScript instead of a Vite bundle.
+  `dist/chess-board.js` is the readable ES2022 output of `src/chess-board.ts`
+  (which ships in the package, so source maps and declaration maps resolve),
+  and `fen-chess-board` is a regular runtime dependency rather than being
+  inlined. Anything that goes through a bundler or an ESM CDN such as esm.sh
+  keeps working unchanged. Loading `dist/chess-board.js` straight from a
+  `<script type="module">` tag with no bundler breaks, because the file now
+  imports the bare specifier `fen-chess-board`; add an import map for it or
+  load the package through an ESM CDN. See "Without a bundler" in the readme.
+
 **Behaviour changes for users of the element**
 
 * Invalid input now throws instead of quietly producing a broken board. This
@@ -24,9 +36,10 @@ Unreleased
   the `MutationObserver` and left the element blank.
 * `move(square, square)` no longer clears the piece; moving onto the same
   square is a no-op.
-* The published bundle targets Vite's `baseline-widely-available` browsers
-  (roughly Chrome/Edge 107, Firefox 104, Safari 16 and newer) and uses
-  `Object.hasOwn`. Version 2.0 targeted Chrome 87, Firefox 78 and Safari 14.
+* The published JavaScript is ES2022 as written (class fields, `??`, `?.`,
+  `Object.hasOwn`), so it needs roughly Chrome/Edge 94, Firefox 93 or Safari
+  15.4 and newer. Version 2.0 was down-levelled to Chrome 87, Firefox 78 and
+  Safari 14.
 
 **Fixed**
 
@@ -42,7 +55,8 @@ Unreleased
   instead of re-parsing the markup for every changed square.
 * The deprecated `cellpadding` / `cellspacing` table attributes are replaced by
   `border-spacing: 0`; rendering is unchanged.
-* `dist/chess-board.js.map` is shipped alongside the bundle.
+* `dist/chess-board.js.map` and `dist/chess-board.d.ts.map` are shipped, and
+  point at the bundled `src/chess-board.ts`.
 * `package.json` is exported as `./package.json`.
 * The `Rank` type is derived from the rank tuple like `File` already was; the
   resulting union is identical.
@@ -51,6 +65,8 @@ Unreleased
 
 * Toolchain: TypeScript 7, Vite 8, Vitest 5, happy-dom 20, pnpm 12. Node 22.12
   or newer is required to work on the repository (consumers are unaffected).
+  Vite now only serves and builds the demo site and runs the tests; `pnpm
+  build` is a single `tsc` invocation.
 * `tsconfig.json` is stricter (`ES2022`, `noUncheckedIndexedAccess`,
   `verbatimModuleSyntax`, `isolatedModules`); `tsconfig.build.json` excludes
   tests from declaration emit; new `pnpm typecheck` script.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "vite build && tsc -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "build:pages": "vite build --config vite.pages.config.ts",
     "dev": "vite",
     "test": "vitest run",
@@ -37,15 +37,19 @@
     "typescript",
     "chess"
   ],
+  "dependencies": {
+    "fen-chess-board": "^4.0.0"
+  },
   "devDependencies": {
-    "fen-chess-board": "^4.0.0",
     "happy-dom": "^20.14.0",
     "typescript": "^7.0.2",
     "vite": "^8.2.2",
     "vitest": "^5.0.0"
   },
   "files": [
-    "dist"
+    "dist",
+    "src",
+    "!src/**/*.test.ts"
   ],
   "packageManager": "pnpm@12.3.4"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,10 +108,11 @@ settings:
 importers:
 
   .:
-    devDependencies:
+    dependencies:
       fen-chess-board:
         specifier: ^4.0.0
         version: 4.0.0
+    devDependencies:
       happy-dom:
         specifier: ^20.14.0
         version: 20.14.0

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,21 @@ Changing the text content later updates the board — it's observed via a
 `MutationObserver`. Malformed FEN in the text content is reported with
 `console.warn` and ignored; the board keeps its current position.
 
+### Without a bundler
+
+The package is plain ES2022 JavaScript that imports its one dependency,
+[`fen-chess-board`](https://www.npmjs.com/package/fen-chess-board), by bare
+specifier. Without a bundler, load it through an ESM CDN that resolves
+dependencies:
+
+```html
+<script type="module">
+  import "https://esm.sh/chess-board";
+</script>
+```
+
+or provide an import map for the dependency and load the file directly.
+
 ### TypeScript
 
 Types for the element, squares and pieces are exported from the package:

--- a/readme.md
+++ b/readme.md
@@ -38,16 +38,19 @@ Changing the text content later updates the board — it's observed via a
 
 The package is plain ES2022 JavaScript that imports its one dependency,
 [`fen-chess-board`](https://www.npmjs.com/package/fen-chess-board), by bare
-specifier. Without a bundler, load it through an ESM CDN that resolves
-dependencies:
+specifier. To use it without a bundler, copy both packages into your static
+files and tell the browser where the dependency lives with an import map:
 
 ```html
-<script type="module">
-  import "https://esm.sh/chess-board";
+<script type="importmap">
+  {
+    "imports": {
+      "fen-chess-board": "/vendor/fen-chess-board/src/fen-chess-board.js"
+    }
+  }
 </script>
+<script type="module" src="/vendor/chess-board/dist/chess-board.js"></script>
 ```
-
-or provide an import map for the dependency and load the file directly.
 
 ### TypeScript
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "emitDeclarationOnly": true
+    "sourceMap": true,
+    "declarationMap": true
   },
   "exclude": ["src/**/*.test.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,8 @@
+// Vite serves and builds the demo site (index.html) and runs the tests.
+// The published package is compiled by tsc alone; see tsconfig.build.json.
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  build: {
-    sourcemap: true,
-    lib: {
-      entry: "src/chess-board.ts",
-      formats: ["es"],
-      fileName: "chess-board",
-    },
-  },
   test: {
     environment: "happy-dom",
   },


### PR DESCRIPTION
## Summary

The package is one TypeScript file with one ESM import; nothing in it needs a bundler. Since 2.0.0 the published `dist/chess-board.js` has nevertheless been a Vite library bundle with `fen-chess-board` inlined and identifiers mangled. This PR publishes what `tsc` emits instead.

- `pnpm build` is now `tsc -p tsconfig.build.json`. Output: readable ES2022 `dist/chess-board.js`, `chess-board.d.ts`, plus `.js.map` and `.d.ts.map`. `src/chess-board.ts` ships in the package (tests excluded) so both maps resolve and go-to-definition lands in the TypeScript source.
- `fen-chess-board` moves from a bundled devDependency to `dependencies` (`^4.0.0`). Consumers' lockfiles now pin and audit it like any other dependency.
- `vite.config.ts` loses `build.lib`; Vite only serves/builds the demo site and runs the tests.
- Readme gets a "Without a bundler" section showing a self-hosted import map for the dependency. No CDN is recommended.
- Changelog: new **Breaking** section for this change; the browser-support bullet now describes ES2022 as written (roughly Chrome/Edge 94, Firefox 93, Safari 15.4) rather than Vite's down-level target.

## What breaks

Loading `dist/chess-board.js` directly from a `<script type="module">` tag with no bundler and no import map stops working, because the file now contains `import FENBoard from "fen-chess-board"`. Bundlers are unaffected, and buildless pages work again with an import map pointing `fen-chess-board` at a self-hosted copy. The demo site goes through Vite and is unaffected.

## Verification

- `pnpm typecheck`, `pnpm test` (27 passing), `pnpm build`, `pnpm build:pages` green; `pnpm install --frozen-lockfile` passes with the updated lockfile.
- Packed the tarball and installed it into a scratch project with npm: `fen-chess-board` is pulled in as a dependency, `import "chess-board"` resolves through `exports`, and under happy-dom the element renders the start position and reports `piece("e1") === "K"`.
- Tarball contents: `dist/` (4 files), `src/chess-board.ts`, `license`, `package.json`, `readme.md`. No test files, no `packageManager` field.

## Suggested version: 3.0.0

This supersedes the 2.1.0 recommendation from #19. The bare `<script>` tag case is a real, if niche, way people used the 2.x file, and it breaks; under semver that is a major. It also gives a clean line for the stricter input validation and the ES2022 baseline already listed in the Unreleased entry, so all of the "you may notice this" changes land in one major instead of being argued into a minor. Rename the `Unreleased` heading to `3.0.0 / <date>` when tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChaqSMq3tG8bvWgpJBmdGC