### PR TITLE
Make the board a table to assistive technology

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,12 +3,23 @@ Unreleased
 
 **Added**
 
-* The board has a text alternative. The element gets `role="img"` and an
-  `aria-label` describing the position in words ("Chess position. White: king
-  e1, queen d1, …"), updated on every change, so a screen reader no longer
-  reads 64 blank table cells. An `aria-label`, `aria-labelledby` or `role`
-  set on the element by the page is left untouched. (#22)
+* The board is a table to assistive technology instead of 64 blank cells.
+  The caption describes the position in words ("Chess position. White: king
+  e1, queen d1, …"), the files and ranks are column and row headers whether
+  or not the frame is shown, and each square holds the name of its piece
+  ("White pawn") next to the picture, which is hidden. A screen reader hears
+  the whole position on entering the board and can walk it square by square.
+  An `aria-label` on the element replaces the caption with the page's own
+  words. The description is also exposed as the `description` property, and
+  the words can be translated by replacing `ChessBoardElement.strings`. (#22)
 
+**Changed**
+
+* The shadow tree is one table instead of a board table nested in a frame
+  table. The border around the board is drawn by its outermost squares, and
+  the frame labels are collapsed to nothing rather than removed when `frame`
+  is off, so that they stay available as headers. Rendering is unchanged
+  apart from sub-pixel positioning of the frame labels.
 
 3.0.0 / 2026-09-05
 ==================

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,14 @@
+Unreleased
+==========
+
+**Added**
+
+* The board has a text alternative. The element gets `role="img"` and an
+  `aria-label` describing the position in words ("Chess position. White: king
+  e1, queen d1, …"), updated on every change, so a screen reader no longer
+  reads 64 blank table cells. An `aria-label`, `aria-labelledby` or `role`
+  set on the element by the page is left untouched. (#22)
+
 
 3.0.0 / 2026-09-05
 ==================

--- a/readme.md
+++ b/readme.md
@@ -163,6 +163,27 @@ q // ♛ black queen
 k // ♚ black king
 ```
 
+## Accessibility
+
+The element is exposed to assistive technology as an image (`role="img"`)
+whose accessible name describes the position in words, and the name is kept
+up to date on every change:
+
+```
+Chess position. White: king e1, queen d1, rooks a1 and h1, bishops c1 and f1,
+knights b1 and g1, pawns a2, b2, c2, d2, e2, f2, g2 and h2. Black: king e8, …
+```
+
+Set `aria-label` or `aria-labelledby` yourself to describe the board in your
+own words, and the element leaves it alone; remove it again to get the
+generated description back. Set `role` yourself to override the image role.
+
+```html
+<chess-board aria-label="Position after 17.Rd8#">
+  3R2k1/5ppp/8/8/8/8/5PPP/6K1
+</chess-board>
+```
+
 ## Development
 
 The repository uses [pnpm](https://pnpm.io) (the version is pinned in

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ files and tell the browser where the dependency lives with an import map:
 Types for the element, squares and pieces are exported from the package:
 
 ```ts
-import type { ChessBoardElement, Square, Piece } from "chess-board";
+import type { ChessBoardElement, ChessBoardStrings, Square, Piece } from "chess-board";
 ```
 
 ## Attributes
@@ -165,23 +165,58 @@ k // ♚ black king
 
 ## Accessibility
 
-The element is exposed to assistive technology as an image (`role="img"`)
-whose accessible name describes the position in words, and the name is kept
-up to date on every change:
+To assistive technology the board is a table. Its caption describes the
+position in words, the files and ranks are column and row headers (also when
+`frame` is off and they are not shown), and each square holds the name of its
+piece. A screen reader announces the whole position on entering the board and
+can then walk it square by square with its table commands:
 
 ```
 Chess position. White: king e1, queen d1, rooks a1 and h1, bishops c1 and f1,
 knights b1 and g1, pawns a2, b2, c2, d2, e2, f2, g2 and h2. Black: king e8, …
 ```
 
-Set `aria-label` or `aria-labelledby` yourself to describe the board in your
-own words, and the element leaves it alone; remove it again to get the
-generated description back. Set `role` yourself to override the image role.
+The same text is available as the `description` property.
+
+Set `aria-label` on the element to replace the caption with your own words,
+and remove it to get the generated description back:
 
 ```html
-<chess-board aria-label="Position after 17.Rd8#">
-  3R2k1/5ppp/8/8/8/8/5PPP/6K1
+<chess-board aria-label="White to move and win">
+  8/8/8/8/4P3/8/8/4K3
 </chess-board>
+```
+
+Two limits to know about:
+
+- Only the piece placement is described. The element does not track the side
+  to move, so say it in your own `aria-label` when it matters.
+- Changes are not announced. `move()`, `fen` and the other methods update the
+  caption and the squares silently, as any table would. A game viewer should
+  announce moves itself, for example in an `aria-live` region.
+
+The words are English by default. Replace `ChessBoardElement.strings` to
+translate them; boards pick the new words up on their next render, so do it
+before the boards are created or set `fen` again afterwards:
+
+```ts
+import { ChessBoardElement } from "chess-board";
+
+ChessBoardElement.strings = {
+  white: "Hvit",
+  black: "Svart",
+  pieces: {
+    K: ["konge", "konger"],
+    Q: ["dronning", "dronninger"],
+    R: ["tårn", "tårn"],
+    B: ["løper", "løpere"],
+    N: ["springer", "springere"],
+    P: ["bonde", "bønder"],
+  },
+  position: "Sjakkstilling.",
+  empty: "Tomt brett.",
+  and: "og",
+};
 ```
 
 ## Development

--- a/src/chess-board.test.ts
+++ b/src/chess-board.test.ts
@@ -299,6 +299,84 @@ describe("chess-board", () => {
     });
   });
 
+  describe("accessibility", () => {
+    const START_LABEL =
+      "Chess position. " +
+      "White: king e1, queen d1, rooks a1 and h1, bishops c1 and f1, " +
+      "knights b1 and g1, pawns a2, b2, c2, d2, e2, f2, g2 and h2. " +
+      "Black: king e8, queen d8, rooks a8 and h8, bishops c8 and f8, " +
+      "knights b8 and g8, pawns a7, b7, c7, d7, e7, f7, g7 and h7.";
+
+    it("exposes the board as an image described by the position", () => {
+      const el = createElement(START_FEN);
+      expect(el.getAttribute("role")).toBe("img");
+      expect(el.getAttribute("aria-label")).toBe(START_LABEL);
+    });
+
+    it("describes an empty board", () => {
+      const el = createElement();
+      expect(el.getAttribute("aria-label")).toBe(
+        "Chess position. Empty board.",
+      );
+    });
+
+    it("leaves out a side that has no pieces", () => {
+      const el = createElement("8/8/8/8/8/8/8/4K3");
+      expect(el.getAttribute("aria-label")).toBe(
+        "Chess position. White: king e1.",
+      );
+    });
+
+    it("updates the description on every change", async () => {
+      const el = createElement(START_FEN);
+      el.move("e2", "e4");
+      expect(el.getAttribute("aria-label")).toContain(
+        "pawns a2, b2, c2, d2, e4, f2, g2 and h2.",
+      );
+      el.clearBoard();
+      expect(el.getAttribute("aria-label")).toBe(
+        "Chess position. Empty board.",
+      );
+      el.textContent = SCHOLARS_MATE;
+      await flushObservers();
+      expect(el.getAttribute("aria-label")).toBe(
+        "Chess position. " +
+          "White: king e1, queen f7, rooks a1 and h1, bishops c1 and c4, " +
+          "knights b1 and g1, pawns a2, b2, c2, d2, e4, f2, g2 and h2. " +
+          "Black: king e8, queen d8, rooks a8 and h8, bishops c8 and f8, " +
+          "knights c6 and f6, pawns a7, b7, c7, d7, e5, g7 and h7.",
+      );
+    });
+
+    it("keeps a role and label supplied by the page", () => {
+      const el = createElement(START_FEN, {
+        role: "figure",
+        "aria-label": "Position after 17.Rd8#",
+      });
+      el.move("e2", "e4");
+      expect(el.getAttribute("role")).toBe("figure");
+      expect(el.getAttribute("aria-label")).toBe("Position after 17.Rd8#");
+    });
+
+    it("does not add a label when the page uses aria-labelledby", () => {
+      const el = createElement(START_FEN, { "aria-labelledby": "caption" });
+      expect(el.hasAttribute("aria-label")).toBe(false);
+    });
+
+    it("lets the page take over the label later, and hand it back", () => {
+      const el = createElement(START_FEN);
+      expect(el.getAttribute("aria-label")).toBe(START_LABEL);
+
+      el.setAttribute("aria-label", "Opening position");
+      el.move("e2", "e4");
+      expect(el.getAttribute("aria-label")).toBe("Opening position");
+
+      el.removeAttribute("aria-label");
+      el.move("e7", "e5");
+      expect(el.getAttribute("aria-label")).toContain("pawns a7, b7, c7, d7, e5");
+    });
+  });
+
   describe("square colors", () => {
     it("assigns correct light/dark classes", () => {
       const el = createElement(START_FEN);

--- a/src/chess-board.test.ts
+++ b/src/chess-board.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "./chess-board";
-import type { ChessBoardElement } from "./chess-board";
+import { ChessBoardElement } from "./chess-board";
+import type { ChessBoardStrings } from "./chess-board";
 
 const START_FEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR";
 const EMPTY_FEN = "8/8/8/8/8/8/8/8";
@@ -32,14 +33,22 @@ function getTable(el: ChessBoardElement): HTMLTableElement {
   return table;
 }
 
+/** The square in board row `row` (0 is rank 8) and column `col` (0 is the a-file). */
 function getCell(
   el: ChessBoardElement,
   row: number,
   col: number,
 ): HTMLTableCellElement {
-  const cell = getTable(el).rows[row]?.cells[col];
-  if (!cell) throw new Error(`no cell at ${row},${col}`);
+  // Each body row starts with the rank header. (happy-dom has no tBodies.)
+  const cell = getTable(el).querySelectorAll("tbody tr")[row]?.children[col + 1];
+  if (!(cell instanceof HTMLTableCellElement) || !cell.classList.contains("square")) {
+    throw new Error(`no square at ${row},${col}`);
+  }
   return cell;
+}
+
+function getCaption(el: ChessBoardElement): string {
+  return getTable(el).querySelector("caption")?.textContent ?? "";
 }
 
 function getPieceAt(
@@ -89,10 +98,12 @@ describe("chess-board", () => {
 
     it("creates an 8x8 board table in shadow DOM", () => {
       const table = getTable(createElement(START_FEN));
-      expect(table.rows.length).toBe(8);
-      for (const row of table.rows) {
-        expect(row.cells.length).toBe(8);
+      const rows = table.querySelectorAll("tbody tr");
+      expect(rows.length).toBe(8);
+      for (const row of rows) {
+        expect(row.querySelectorAll("td.square").length).toBe(8);
       }
+      expect(table.querySelectorAll("td.square").length).toBe(64);
     });
   });
 
@@ -307,39 +318,75 @@ describe("chess-board", () => {
       "Black: king e8, queen d8, rooks a8 and h8, bishops c8 and f8, " +
       "knights b8 and g8, pawns a7, b7, c7, d7, e7, f7, g7 and h7.";
 
-    it("exposes the board as an image described by the position", () => {
+    it("captions the table with a description of the position", () => {
       const el = createElement(START_FEN);
-      expect(el.getAttribute("role")).toBe("img");
-      expect(el.getAttribute("aria-label")).toBe(START_LABEL);
+      expect(getCaption(el)).toBe(START_LABEL);
+      expect(el.description).toBe(START_LABEL);
+      expect(el.hasAttribute("role")).toBe(false);
+      expect(el.hasAttribute("aria-label")).toBe(false);
     });
 
     it("describes an empty board", () => {
       const el = createElement();
-      expect(el.getAttribute("aria-label")).toBe(
-        "Chess position. Empty board.",
-      );
+      expect(getCaption(el)).toBe("Chess position. Empty board.");
     });
 
     it("leaves out a side that has no pieces", () => {
       const el = createElement("8/8/8/8/8/8/8/4K3");
-      expect(el.getAttribute("aria-label")).toBe(
-        "Chess position. White: king e1.",
+      expect(getCaption(el)).toBe("Chess position. White: king e1.");
+    });
+
+    it("pluralises a group of promoted pieces", () => {
+      const el = createElement("8/8/8/8/4Q3/8/8/3Q3Q");
+      expect(getCaption(el)).toBe(
+        "Chess position. White: queens d1, e4 and h1.",
       );
     });
 
-    it("updates the description on every change", async () => {
+    it("labels the files and ranks as table headers", () => {
+      const table = getTable(createElement(START_FEN));
+      const files = Array.from(table.querySelectorAll("thead th[scope=col]"));
+      expect(files.map((th) => th.textContent)).toEqual([
+        "a", "b", "c", "d", "e", "f", "g", "h",
+      ]);
+      const ranks = Array.from(table.querySelectorAll("tbody th[scope=row]"));
+      expect(ranks.map((th) => th.textContent)).toEqual([
+        "8", "7", "6", "5", "4", "3", "2", "1",
+      ]);
+      // The duplicate labels on the right and at the bottom are decoration.
+      for (const cell of table.querySelectorAll("tbody .frame.right")) {
+        expect(cell.getAttribute("aria-hidden")).toBe("true");
+      }
+      expect(table.querySelector("tfoot tr")?.getAttribute("aria-hidden")).toBe(
+        "true",
+      );
+    });
+
+    it("names the piece on each square and hides the picture", () => {
+      const el = createElement(START_FEN);
+      expect(getCell(el, 0, 0).textContent).toBe("Black rook");
+      expect(getCell(el, 7, 4).textContent).toBe("White king");
+      expect(getCell(el, 3, 3).textContent).toBe("");
+      expect(getCell(el, 0, 0).querySelector("svg")?.getAttribute("aria-hidden"))
+        .toBe("true");
+
+      el.setAttribute("unicode", "");
+      expect(getCell(el, 0, 0).textContent).toBe("♜Black rook");
+      const glyph = getCell(el, 0, 0).querySelector("span.piece");
+      expect(glyph?.getAttribute("aria-hidden")).toBe("true");
+    });
+
+    it("updates the caption and the squares on every change", async () => {
       const el = createElement(START_FEN);
       el.move("e2", "e4");
-      expect(el.getAttribute("aria-label")).toContain(
-        "pawns a2, b2, c2, d2, e4, f2, g2 and h2.",
-      );
+      expect(getCaption(el)).toContain("pawns a2, b2, c2, d2, e4, f2, g2 and h2.");
+      expect(getCell(el, 4, 4).textContent).toBe("White pawn");
+      expect(getCell(el, 6, 4).textContent).toBe("");
       el.clearBoard();
-      expect(el.getAttribute("aria-label")).toBe(
-        "Chess position. Empty board.",
-      );
+      expect(getCaption(el)).toBe("Chess position. Empty board.");
       el.textContent = SCHOLARS_MATE;
       await flushObservers();
-      expect(el.getAttribute("aria-label")).toBe(
+      expect(getCaption(el)).toBe(
         "Chess position. " +
           "White: king e1, queen f7, rooks a1 and h1, bishops c1 and c4, " +
           "knights b1 and g1, pawns a2, b2, c2, d2, e4, f2, g2 and h2. " +
@@ -348,32 +395,76 @@ describe("chess-board", () => {
       );
     });
 
-    it("keeps a role and label supplied by the page", () => {
+    it("is not changed by the reverse attribute", () => {
+      const el = createElement(START_FEN, { reverse: "" });
+      expect(getCaption(el)).toBe(START_LABEL);
+      expect(getCell(el, 0, 0).textContent).toBe("Black rook");
+    });
+
+    it("uses an aria-label from the page as the caption instead", () => {
       const el = createElement(START_FEN, {
-        role: "figure",
         "aria-label": "Position after 17.Rd8#",
       });
+      expect(getCaption(el)).toBe("Position after 17.Rd8#");
       el.move("e2", "e4");
-      expect(el.getAttribute("role")).toBe("figure");
-      expect(el.getAttribute("aria-label")).toBe("Position after 17.Rd8#");
+      expect(getCaption(el)).toBe("Position after 17.Rd8#");
+      expect(el.description).toContain("e4");
     });
 
-    it("does not add a label when the page uses aria-labelledby", () => {
-      const el = createElement(START_FEN, { "aria-labelledby": "caption" });
-      expect(el.hasAttribute("aria-label")).toBe(false);
-    });
-
-    it("lets the page take over the label later, and hand it back", () => {
+    it("follows the aria-label as it is set, changed and removed", () => {
       const el = createElement(START_FEN);
-      expect(el.getAttribute("aria-label")).toBe(START_LABEL);
-
       el.setAttribute("aria-label", "Opening position");
-      el.move("e2", "e4");
-      expect(el.getAttribute("aria-label")).toBe("Opening position");
-
+      expect(getCaption(el)).toBe("Opening position");
+      el.setAttribute("aria-label", "Before 1.e4");
+      expect(getCaption(el)).toBe("Before 1.e4");
       el.removeAttribute("aria-label");
-      el.move("e7", "e5");
-      expect(el.getAttribute("aria-label")).toContain("pawns a7, b7, c7, d7, e5");
+      expect(getCaption(el)).toBe(START_LABEL);
+    });
+
+    it("treats an empty aria-label as no label", () => {
+      const el = createElement(START_FEN, { "aria-label": "" });
+      expect(getCaption(el)).toBe(START_LABEL);
+    });
+
+    it("keeps the caption across disconnect and reconnect", () => {
+      const el = createElement();
+      el.fen = START_FEN;
+      document.body.removeChild(el);
+      el.move("e2", "e4");
+      document.body.appendChild(el);
+      expect(getCaption(el)).toContain("pawns a2, b2, c2, d2, e4, f2, g2 and h2.");
+      expect(getCell(el, 4, 4).textContent).toBe("White pawn");
+    });
+
+    it("can be translated by replacing the strings", () => {
+      const english = ChessBoardElement.strings;
+      const norwegian: ChessBoardStrings = {
+        white: "Hvit",
+        black: "Svart",
+        pieces: {
+          K: ["konge", "konger"],
+          Q: ["dronning", "dronninger"],
+          R: ["tårn", "tårn"],
+          B: ["løper", "løpere"],
+          N: ["springer", "springere"],
+          P: ["bonde", "bønder"],
+        },
+        position: "Sjakkstilling.",
+        empty: "Tomt brett.",
+        and: "og",
+      };
+      try {
+        ChessBoardElement.strings = norwegian;
+        const el = createElement("8/8/8/8/8/8/8/R3K2R");
+        expect(getCaption(el)).toBe(
+          "Sjakkstilling. Hvit: konge e1, tårn a1 og h1.",
+        );
+        expect(getCell(el, 7, 0).textContent).toBe("Hvit tårn");
+        el.clearBoard();
+        expect(getCaption(el)).toBe("Sjakkstilling. Tomt brett.");
+      } finally {
+        ChessBoardElement.strings = english;
+      }
     });
   });
 

--- a/src/chess-board.ts
+++ b/src/chess-board.ts
@@ -26,6 +26,68 @@ const UNICODE_PIECES: Record<Piece, string> = {
   p: "\u265F",
 };
 
+const PIECE_NAMES: Record<Piece, string> = {
+  K: "king",
+  Q: "queen",
+  R: "rook",
+  B: "bishop",
+  N: "knight",
+  P: "pawn",
+  k: "king",
+  q: "queen",
+  r: "rook",
+  b: "bishop",
+  n: "knight",
+  p: "pawn",
+};
+
+const WHITE_PIECES: readonly WhitePiece[] = ["K", "Q", "R", "B", "N", "P"];
+const BLACK_PIECES: readonly BlackPiece[] = ["k", "q", "r", "b", "n", "p"];
+
+function joinSquares(squares: readonly string[]): string {
+  if (squares.length < 2) return squares.join("");
+  return `${squares.slice(0, -1).join(", ")} and ${squares.at(-1)}`;
+}
+
+/**
+ * Describe a position in words for the accessible name of the board:
+ * "Chess position. White: king e1, queen d1, rooks a1 and h1, ...
+ * Black: king e8, ..." Pieces are grouped by type and listed by file, then
+ * rank, so a pawn chain reads a2, b3, c4.
+ *
+ * @param board - The board as returned by FENBoard: row 0 is rank 8.
+ */
+function describePosition(board: readonly (readonly string[])[]): string {
+  const squares = new Map<Piece, string[]>();
+  for (const [f, file] of FILES.entries()) {
+    for (let r = RANKS.length - 1; r >= 0; r--) {
+      const piece = board[r]?.[f] ?? "";
+      if (!isPiece(piece)) continue;
+      const list = squares.get(piece) ?? [];
+      list.push(`${file}${RANKS[r]}`);
+      squares.set(piece, list);
+    }
+  }
+
+  const describeSide = (name: string, pieces: readonly Piece[]): string => {
+    const groups = pieces.flatMap((piece) => {
+      const list = squares.get(piece);
+      if (!list) return [];
+      const plural = list.length > 1 ? "s" : "";
+      return [`${PIECE_NAMES[piece]}${plural} ${joinSquares(list)}`];
+    });
+    return groups.length ? `${name}: ${groups.join(", ")}.` : "";
+  };
+
+  const sides = [
+    describeSide("White", WHITE_PIECES),
+    describeSide("Black", BLACK_PIECES),
+  ].filter(Boolean);
+  return ["Chess position.", ...(sides.length ? sides : ["Empty board."])].join(
+    " ",
+  );
+}
+
 // SVG piece definitions — viewBox 0 0 45 45, standard chess piece vectors
 const SVG_PIECES: Record<Piece, string> = {
   P: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 45 45" class="piece"><path d="M 22,9 C 19.79,9 18,10.79 18,13 C 18,13.89 18.29,14.71 18.78,15.38 C 16.83,16.5 15.5,18.59 15.5,21 C 15.5,23.03 16.44,24.84 17.91,26.03 C 14.91,27.09 10.5,31.58 10.5,39.5 L 33.5,39.5 C 33.5,31.58 29.09,27.09 26.09,26.03 C 27.56,24.84 28.5,23.03 28.5,21 C 28.5,18.59 27.17,16.5 25.22,15.38 C 25.71,14.71 26,13.89 26,13 C 26,10.79 24.21,9 22,9 z" style="fill:#fff;stroke:#000;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:miter"/></svg>`,
@@ -189,6 +251,8 @@ export class ChessBoardElement extends HTMLElement {
   private readonly _cells: HTMLTableCellElement[];
   private _observer: MutationObserver | null = null;
   private _lastUnicode = false;
+  /** The aria-label this element wrote last, to tell it from an author's. */
+  private _generatedLabel: string | null = null;
 
   // "reverse" and "frame" are handled purely by CSS :host() selectors
   // and do not require JS re-rendering.
@@ -209,6 +273,10 @@ export class ChessBoardElement extends HTMLElement {
     // empty at construction time — this is why we read it here and also
     // why the MutationObserver exists.
     this._applyTextContent();
+    // Assistive technology sees the board as one image described by its
+    // aria-label (see _updateLabel), unless the page gave it another role.
+    // Attributes may not be added in the constructor, hence here.
+    if (!this.hasAttribute("role")) this.setAttribute("role", "img");
     this._renderBoard();
 
     // connectedCallback may fire multiple times if the element is moved.
@@ -310,6 +378,23 @@ export class ChessBoardElement extends HTMLElement {
         cell.replaceChildren(createPieceElement(piece, useUnicode));
       }
     });
+
+    this._updateLabel(board);
+  }
+
+  /**
+   * Keep the accessible name in step with the position, unless the page
+   * supplies its own with aria-label or aria-labelledby. A label written
+   * here is recognised by its value, so an author can take over at any time
+   * by setting aria-label to something else, and hand back by removing it.
+   */
+  private _updateLabel(board: readonly (readonly string[])[]): void {
+    if (this.hasAttribute("aria-labelledby")) return;
+    const current = this.getAttribute("aria-label");
+    if (current !== null && current !== this._generatedLabel) return;
+    const label = describePosition(board);
+    if (label !== current) this.setAttribute("aria-label", label);
+    this._generatedLabel = label;
   }
 }
 

--- a/src/chess-board.ts
+++ b/src/chess-board.ts
@@ -26,38 +26,71 @@ const UNICODE_PIECES: Record<Piece, string> = {
   p: "\u265F",
 };
 
-const PIECE_NAMES: Record<Piece, string> = {
-  K: "king",
-  Q: "queen",
-  R: "rook",
-  B: "bishop",
-  N: "knight",
-  P: "pawn",
-  k: "king",
-  q: "queen",
-  r: "rook",
-  b: "bishop",
-  n: "knight",
-  p: "pawn",
+/**
+ * The words the element uses for assistive technology. Replace
+ * `ChessBoardElement.strings` to translate them; boards pick the new words
+ * up on their next render.
+ */
+export interface ChessBoardStrings {
+  /** Colour names, capitalised: "White pawn", "White: king e1, ...". */
+  white: string;
+  black: string;
+  /** Piece names by type, singular and plural. */
+  pieces: Record<WhitePiece, readonly [singular: string, plural: string]>;
+  /** Opens the description of the position. */
+  position: string;
+  /** Describes a board without pieces. */
+  empty: string;
+  /** Joins the last two squares of a list: "a1 and h1". */
+  and: string;
+}
+
+const ENGLISH: ChessBoardStrings = {
+  white: "White",
+  black: "Black",
+  pieces: {
+    K: ["king", "kings"],
+    Q: ["queen", "queens"],
+    R: ["rook", "rooks"],
+    B: ["bishop", "bishops"],
+    N: ["knight", "knights"],
+    P: ["pawn", "pawns"],
+  },
+  position: "Chess position.",
+  empty: "Empty board.",
+  and: "and",
 };
 
 const WHITE_PIECES: readonly WhitePiece[] = ["K", "Q", "R", "B", "N", "P"];
 const BLACK_PIECES: readonly BlackPiece[] = ["k", "q", "r", "b", "n", "p"];
 
-function joinSquares(squares: readonly string[]): string {
+function pieceType(piece: Piece): WhitePiece {
+  return piece.toUpperCase() as WhitePiece;
+}
+
+/** The name of a piece for a square's text: "White pawn". */
+function pieceName(piece: Piece, strings: ChessBoardStrings): string {
+  const colour = piece === pieceType(piece) ? strings.white : strings.black;
+  return `${colour} ${strings.pieces[pieceType(piece)][0]}`;
+}
+
+function joinSquares(squares: readonly string[], and: string): string {
   if (squares.length < 2) return squares.join("");
-  return `${squares.slice(0, -1).join(", ")} and ${squares.at(-1)}`;
+  return `${squares.slice(0, -1).join(", ")} ${and} ${squares.at(-1)}`;
 }
 
 /**
- * Describe a position in words for the accessible name of the board:
+ * Describe a position in words for the caption of the board:
  * "Chess position. White: king e1, queen d1, rooks a1 and h1, ...
  * Black: king e8, ..." Pieces are grouped by type and listed by file, then
  * rank, so a pawn chain reads a2, b3, c4.
  *
  * @param board - The board as returned by FENBoard: row 0 is rank 8.
  */
-function describePosition(board: readonly (readonly string[])[]): string {
+function describePosition(
+  board: readonly (readonly string[])[],
+  strings: ChessBoardStrings,
+): string {
   const squares = new Map<Piece, string[]>();
   for (const [f, file] of FILES.entries()) {
     for (let r = RANKS.length - 1; r >= 0; r--) {
@@ -73,17 +106,18 @@ function describePosition(board: readonly (readonly string[])[]): string {
     const groups = pieces.flatMap((piece) => {
       const list = squares.get(piece);
       if (!list) return [];
-      const plural = list.length > 1 ? "s" : "";
-      return [`${PIECE_NAMES[piece]}${plural} ${joinSquares(list)}`];
+      const [singular, plural] = strings.pieces[pieceType(piece)];
+      const noun = list.length > 1 ? plural : singular;
+      return [`${noun} ${joinSquares(list, strings.and)}`];
     });
     return groups.length ? `${name}: ${groups.join(", ")}.` : "";
   };
 
   const sides = [
-    describeSide("White", WHITE_PIECES),
-    describeSide("Black", BLACK_PIECES),
+    describeSide(strings.white, WHITE_PIECES),
+    describeSide(strings.black, BLACK_PIECES),
   ].filter(Boolean);
-  return ["Chess position.", ...(sides.length ? sides : ["Empty board."])].join(
+  return [strings.position, ...(sides.length ? sides : [strings.empty])].join(
     " ",
   );
 }
@@ -119,39 +153,65 @@ const STYLES = `
 :host {
   display: inline-block;
 }
-table { border-spacing: 0; }
-.frame { display: none; }
+.chess-board {
+  border-spacing: 0;
+  position: relative;
+}
+td, th {
+  padding: 0;
+  text-align: center;
+  font-weight: normal;
+}
+/* Read by assistive technology, never seen: the caption, the file and rank
+   labels while the frame is hidden, and the name of the piece on a square. */
+caption, .frame > span, .name {
+  position: absolute;
+  width: 1px; height: 1px;
+  margin: -1px; padding: 0; border: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+.frame {
+  width: 0; height: 0;
+  font-size: 40%;
+}
 :host([frame]) .frame {
   width: 1em; height: 1em;
-  display: table-cell;
-  font-size: 40%;
+}
+:host([frame]) .frame > span {
+  position: static;
+  width: auto; height: auto;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+  clip-path: none;
+  white-space: normal;
 }
 :host([frame]) .frame.left,
 :host([frame]) .frame.right {
   vertical-align: middle;
   padding: 0.2em;
 }
-:host([frame]) .frame.top,
-:host([frame]) .frame.bottom {
-  text-align: center;
-}
-:host([reverse]) .board-frame {
+:host([reverse]) .chess-board {
   transform: rotate(180deg);
 }
 :host([reverse]) .frame {
   transform: rotate(180deg);
 }
-.chess-board {
-  border: 1px solid black;
-  border-collapse: collapse;
+.square {
+  width: 1em; height: 1em;
 }
 .light { background: #FFCE9E; }
 .dark  { background: #D18B47; }
-td {
-  width: 1em; height: 1em;
-  text-align: center;
-  padding: 0;
-}
+/* The border around the 8x8 board is drawn by its outermost squares, since
+   the table itself also holds the frame labels. Borders are not collapsed,
+   so each one is a plain part of its square's box. */
+tbody tr:first-child .square { border-top: 1px solid black; }
+tbody tr:last-child .square { border-bottom: 1px solid black; }
+.square:nth-child(2) { border-left: 1px solid black; }
+.square:nth-child(9) { border-right: 1px solid black; }
 .piece, .empty {
   width: 1em; height: 1em;
   display: block;
@@ -165,43 +225,39 @@ td {
 }
 `;
 
+// One table, so that assistive technology can walk it: the caption is the
+// description of the position, the files are column headers, the ranks are
+// row headers and each square holds the name of its piece. The labels on the
+// right and at the bottom repeat the headers and are hidden from it.
 function buildBoardHTML(): string {
   let html = `<style>${STYLES}</style>`;
-  html += `<table class="board-frame">`;
+  html += `<table class="chess-board"><caption></caption>`;
 
   // Top frame row
-  html += `<tr><td class="frame top left"></td>`;
-  for (const file of FILES) html += `<td class="frame top">${file}</td>`;
-  html += `<td class="frame top right"></td></tr>`;
+  html += `<thead><tr><td class="frame top left"></td>`;
+  for (const file of FILES) {
+    html += `<th scope="col" class="frame top"><span>${file}</span></th>`;
+  }
+  html += `<td class="frame top right"></td></tr></thead>`;
 
   // Board rows with side frames
-  for (const [ri, rank] of RANKS.entries()) {
-    html += `<tr>`;
-    html += `<td class="frame left">${rank}</td>`;
-
-    if (ri === 0) {
-      // First rank row contains the nested chess board table
-      html += `<td colspan="8" rowspan="8" class="board-wrap">`;
-      html += `<table class="chess-board">`;
-      for (const [r, boardRank] of RANKS.entries()) {
-        html += `<tr>`;
-        for (const [f, file] of FILES.entries()) {
-          const shade = (r + f) % 2 === 0 ? "light" : "dark";
-          html += `<td class="${file}${boardRank} ${shade}"><span class="empty" data-piece=""></span></td>`;
-        }
-        html += `</tr>`;
-      }
-      html += `</table></td>`;
+  html += `<tbody>`;
+  for (const [r, rank] of RANKS.entries()) {
+    html += `<tr><th scope="row" class="frame left"><span>${rank}</span></th>`;
+    for (const [f, file] of FILES.entries()) {
+      const shade = (r + f) % 2 === 0 ? "light" : "dark";
+      html += `<td class="square ${file}${rank} ${shade}"><span class="empty" data-piece=""></span></td>`;
     }
-
-    html += `<td class="frame right">${rank}</td>`;
-    html += `</tr>`;
+    html += `<td class="frame right" aria-hidden="true"><span>${rank}</span></td></tr>`;
   }
+  html += `</tbody>`;
 
   // Bottom frame row
-  html += `<tr><td class="frame bottom left"></td>`;
-  for (const file of FILES) html += `<td class="frame bottom">${file}</td>`;
-  html += `<td class="frame bottom right"></td></tr>`;
+  html += `<tfoot><tr aria-hidden="true"><td class="frame bottom left"></td>`;
+  for (const file of FILES) {
+    html += `<td class="frame bottom"><span>${file}</span></td>`;
+  }
+  html += `<td class="frame bottom right"></td></tr></tfoot>`;
 
   html += `</table>`;
   return html;
@@ -226,45 +282,62 @@ function svgPiece(piece: Piece): SVGElement {
   return template.cloneNode(true) as SVGElement;
 }
 
-function createPieceElement(pieceChar: string, unicode: boolean): Element {
+/**
+ * The contents of a square: the piece as a picture or glyph, hidden from
+ * assistive technology, followed by its name as hidden text. The first
+ * element carries data-piece so that rendering can tell what is on the
+ * square without parsing it.
+ */
+function createSquareContents(
+  pieceChar: string,
+  unicode: boolean,
+  strings: ChessBoardStrings,
+): Element[] {
   if (!isPiece(pieceChar)) {
     const span = document.createElement("span");
     span.className = "empty";
     span.setAttribute("data-piece", "");
-    return span;
+    return [span];
   }
+  let piece: Element;
   if (unicode) {
-    const span = document.createElement("span");
-    span.className = "piece";
-    span.setAttribute("data-piece", pieceChar);
-    span.textContent = UNICODE_PIECES[pieceChar];
-    return span;
+    piece = document.createElement("span");
+    piece.className = "piece";
+    piece.textContent = UNICODE_PIECES[pieceChar];
+  } else {
+    piece = svgPiece(pieceChar);
   }
-  const svg = svgPiece(pieceChar);
-  svg.setAttribute("data-piece", pieceChar);
-  return svg;
+  piece.setAttribute("data-piece", pieceChar);
+  piece.setAttribute("aria-hidden", "true");
+  const name = document.createElement("span");
+  name.className = "name";
+  name.textContent = pieceName(pieceChar, strings);
+  return [piece, name];
 }
 
 export class ChessBoardElement extends HTMLElement {
+  /** The words used for assistive technology; replace to translate. */
+  static strings: ChessBoardStrings = ENGLISH;
+
   private readonly _board = new FENBoard();
   /** The 64 board cells in row-major order: index 0 is a8, index 63 is h1. */
   private readonly _cells: HTMLTableCellElement[];
+  private readonly _caption: HTMLTableCaptionElement;
   private _observer: MutationObserver | null = null;
   private _lastUnicode = false;
-  /** The aria-label this element wrote last, to tell it from an author's. */
-  private _generatedLabel: string | null = null;
 
   // "reverse" and "frame" are handled purely by CSS :host() selectors
-  // and do not require JS re-rendering.
+  // and do not require JS re-rendering. "aria-label" replaces the caption.
   static get observedAttributes(): string[] {
-    return ["unicode"];
+    return ["unicode", "aria-label"];
   }
 
   constructor() {
     super();
     const shadow = this.attachShadow({ mode: "open" });
     shadow.innerHTML = buildBoardHTML();
-    this._cells = Array.from(shadow.querySelectorAll(".chess-board td"));
+    this._cells = Array.from(shadow.querySelectorAll(".square"));
+    this._caption = shadow.querySelector("caption") as HTMLTableCaptionElement;
   }
 
   connectedCallback(): void {
@@ -273,10 +346,6 @@ export class ChessBoardElement extends HTMLElement {
     // empty at construction time — this is why we read it here and also
     // why the MutationObserver exists.
     this._applyTextContent();
-    // Assistive technology sees the board as one image described by its
-    // aria-label (see _updateLabel), unless the page gave it another role.
-    // Attributes may not be added in the constructor, hence here.
-    if (!this.hasAttribute("role")) this.setAttribute("role", "img");
     this._renderBoard();
 
     // connectedCallback may fire multiple times if the element is moved.
@@ -306,6 +375,8 @@ export class ChessBoardElement extends HTMLElement {
   ): void {
     if (name === "unicode") {
       this._renderBoard();
+    } else if (name === "aria-label") {
+      this._updateCaption();
     }
   }
 
@@ -316,6 +387,15 @@ export class ChessBoardElement extends HTMLElement {
   set fen(value: string) {
     this._board.fen = value;
     this._renderBoard();
+  }
+
+  /**
+   * The description of the position that assistive technology reads as
+   * the caption of the board, in the words of `ChessBoardElement.strings`.
+   * An `aria-label` on the element replaces it.
+   */
+  get description(): string {
+    return describePosition(this._board.board, ChessBoardElement.strings);
   }
 
   piece(square: Square): PieceOrEmpty {
@@ -366,6 +446,7 @@ export class ChessBoardElement extends HTMLElement {
 
   private _renderBoard(): void {
     const board = this._board.board;
+    const strings = ChessBoardElement.strings;
     const useUnicode = this.hasAttribute("unicode");
     const modeChanged = useUnicode !== this._lastUnicode;
     this._lastUnicode = useUnicode;
@@ -375,26 +456,19 @@ export class ChessBoardElement extends HTMLElement {
       const currentPiece = cell.firstElementChild?.getAttribute("data-piece");
 
       if (piece !== currentPiece || modeChanged) {
-        cell.replaceChildren(createPieceElement(piece, useUnicode));
+        cell.replaceChildren(...createSquareContents(piece, useUnicode, strings));
       }
     });
 
-    this._updateLabel(board);
+    this._updateCaption();
   }
 
-  /**
-   * Keep the accessible name in step with the position, unless the page
-   * supplies its own with aria-label or aria-labelledby. A label written
-   * here is recognised by its value, so an author can take over at any time
-   * by setting aria-label to something else, and hand back by removing it.
-   */
-  private _updateLabel(board: readonly (readonly string[])[]): void {
-    if (this.hasAttribute("aria-labelledby")) return;
-    const current = this.getAttribute("aria-label");
-    if (current !== null && current !== this._generatedLabel) return;
-    const label = describePosition(board);
-    if (label !== current) this.setAttribute("aria-label", label);
-    this._generatedLabel = label;
+  /** The caption is the page's aria-label if it set one, else the description. */
+  private _updateCaption(): void {
+    const caption = this.getAttribute("aria-label") || this.description;
+    if (this._caption.textContent !== caption) {
+      this._caption.textContent = caption;
+    }
   }
 }
 


### PR DESCRIPTION
Closes #22.

## What

To assistive technology the board is now a real table rather than 64 blank cells. Nothing changes visually.

- The **caption** is a description of the position in words, regenerated on every render:

  ```
  Chess position. White: king e1, queen d1, rooks a1 and h1, bishops c1 and f1,
  knights b1 and g1, pawns a2, b2, c2, d2, e2, f2, g2 and h2. Black: king e8, …
  ```

  Pieces are grouped by type and listed by file, then rank. An empty board reads `Chess position. Empty board.`, and a side with no pieces is left out.
- The **files and ranks are `<th scope="col">` and `<th scope="row">`**, whether or not `frame` is on. The duplicate labels on the right and at the bottom are `aria-hidden`.
- **Each square holds the name of its piece** (`White pawn`) as visually hidden text next to the picture, which is `aria-hidden`. Empty squares stay empty.

So a screen reader hears the whole position on entering the board, and can then walk it square by square with its table commands, which `role="img"` in the first version of this PR ruled out. The Chromium accessibility tree, with the frame off:

```
table "Chess position. White: king e1, pawn e4."
  columnheader "a" … columnheader "h"
  rowheader "8" … rowheader "1"
  cell "White pawn"     (e4)
  cell "White king"     (e1)
```

## Page overrides and API

- `aria-label` on the element replaces the caption with the page's own words. The attribute is observed, so it can be set, changed and removed at any time; an empty value counts as none. There is no ownership heuristic any more, and the element no longer writes any attribute on itself.
- `description` property: the generated text, for pages that want to build their own label from it.
- `ChessBoardElement.strings`: the English words (colours, piece names singular and plural, "Chess position.", "Empty board.", "and") as a replaceable static, for translation. Boards pick a replacement up on their next render.

## Structure change

The shadow tree was a board table nested in a frame table; it is now one table, since headers and squares must share one. Two consequences, both invisible:

- With `frame` off the label cells are collapsed to zero size and their text is clipped (the usual visually-hidden technique), instead of `display: none`, so they stay in the accessibility tree as headers.
- The border around the board is drawn by its outermost squares, as the table now also holds the frame. Borders are not collapsed, so the geometry is plain. Pixel comparison against master in Chromium at 40px and 13px: the unframed boards (default, `reverse`) are byte-identical screenshots; the framed ones differ only in sub-pixel positions of the label glyphs, because the a- and h-file columns are now 41px (border inside) rather than an even 40.25px split of the old inner table. The board and pieces are identical.

## Review items

- **`aria-label=""`**: no `role="img"` exists any more, so no unnamed image. Empty counts as no label and the caption is generated.
- **Stale label after `aria-labelledby`**: the element writes no attribute on itself now, so nothing goes stale. `aria-labelledby` is not consumed (the shadow table cannot reference light-DOM ids); the readme documents `aria-label`.
- **MutationObserver**: it watches `childList`, `characterData` and `subtree` only, never `attributes`, and the element now writes only into its shadow root, so there is no feedback path.
- **Side to move**: not tracked by the element (only the placement field of a FEN is parsed, and `move()` would make any remembered value wrong), so the readme says so and points at `aria-label`.
- **Announcing changes**: documented as a limit in the readme, with `aria-live` as the consumer's tool. An opt-in live region is a follow-up.
- **Hardcoded English**: `ChessBoardElement.strings`.
- **Tests**: 13 accessibility tests, including `aria-label=""`, set/change/remove of `aria-label`, `reverse`, disconnect/reconnect, three promoted queens (`queens d1, e4 and h1`), headers, cell names in both SVG and unicode mode, and a Norwegian translation.

One open point: `aria-label` on the host is technically an attribute on an element with no role. It is the mechanism the issue asked for and browsers handle it, but if a validator complains, a `label` attribute would be the alternative.

`pnpm typecheck`, `pnpm test` (40 tests), `pnpm build` and `pnpm build:pages` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VxKhiVNXdQ8Z1grVs38gY6