### PR TITLE
Add styling hooks: custom properties and ::part() on squares

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,19 @@
+Unreleased
+==========
+
+**Added**
+
+* The board can be themed from the page. The square colours, the board
+  border and the frame label size read the custom properties
+  `--chess-board-light`, `--chess-board-dark`, `--chess-board-border` and
+  `--chess-board-frame-font-size`, with the previous hard-coded values as
+  defaults, so nothing changes unless a page sets them.
+* Squares can be styled from the page with `::part()`: every cell carries
+  `part="square <name> <shade>"` (for example `square e4 light`), the 8×8
+  table is `part="board"` and the file and rank labels are `part="frame"`.
+  A game viewer can now highlight the last move with
+  `chess-board::part(e2), chess-board::part(e4) { … }`. (#21)
+
 
 3.0.0 / 2026-09-05
 ==================

--- a/index.html
+++ b/index.html
@@ -92,6 +92,31 @@
     <chess-board unicode reverse frame>rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR</chess-board>
   </div>
 
+  <h2>Custom Colours</h2>
+  <p>The square colours and the border are CSS custom properties.</p>
+  <div class="example">
+    <style>
+      .green {
+        --chess-board-light: #eeeed2;
+        --chess-board-dark: #769656;
+        --chess-board-border: none;
+      }
+    </style>
+    <chess-board class="green">rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR</chess-board>
+  </div>
+
+  <h2>Highlighted Squares</h2>
+  <p>Every square is a <code>::part()</code> named after it, so a page can mark the last move.</p>
+  <div class="example">
+    <style>
+      .last-move::part(e2),
+      .last-move::part(e4) {
+        box-shadow: inset 0 0 0 0.15em #f0d13a;
+      }
+    </style>
+    <chess-board class="last-move">rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR</chess-board>
+  </div>
+
   <h2>JavaScript API</h2>
   <div class="example">
     <chess-board id="api-demo" frame>rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR</chess-board>
@@ -120,7 +145,14 @@
         }
       }
       const fen = board.textContent.trim();
-      const source = `<chess-board${attrs.join('')}>\n  ${fen}\n</chess-board>`;
+      let source = `<chess-board${attrs.join('')}>\n  ${fen}\n</chess-board>`;
+
+      // Examples that need CSS carry it in a <style>; show it with the markup.
+      const style = example.querySelector('style');
+      if (style) {
+        const css = style.textContent.replace(/^ {6}/gm, '').trim();
+        source = `<style>\n${css}\n</style>\n\n${source}`;
+      }
 
       const sourceBlock = document.createElement('div');
       sourceBlock.className = 'example-source';

--- a/readme.md
+++ b/readme.md
@@ -142,6 +142,54 @@ Remove all pieces from the board.
 board.clearBoard();
 ```
 
+## Styling
+
+The board sizes itself from the element's `font-size`: one square is `1em`.
+Its colours can be changed with custom properties on the element (or any
+ancestor); the defaults are the values the board has always used.
+
+| Property                        | Default           | Applies to                     |
+| ------------------------------- | ----------------- | ------------------------------ |
+| `--chess-board-light`           | `#FFCE9E`         | Light squares                  |
+| `--chess-board-dark`            | `#D18B47`         | Dark squares                   |
+| `--chess-board-border`          | `1px solid black` | Border around the 8×8 board    |
+| `--chess-board-frame-font-size` | `40%`             | File and rank labels (`frame`) |
+
+```css
+chess-board {
+  font-size: 48px;
+  --chess-board-light: #eeeed2;
+  --chess-board-dark: #769656;
+  --chess-board-border: none;
+}
+```
+
+For anything else, the parts of the shadow tree can be styled with
+[`::part()`](https://developer.mozilla.org/docs/Web/CSS/::part). Every square
+carries the parts `square`, its own name and its shade, so a page can mark
+the last move or a square under discussion:
+
+| Part                    | Element                                                  |
+| ----------------------- | -------------------------------------------------------- |
+| `board`                 | The 8×8 table                                            |
+| `square`                | Every square                                             |
+| `a1` … `h8`             | One square                                               |
+| `light`, `dark`         | The squares of one shade                                 |
+| `frame`                 | The file and rank labels shown by the `frame` attribute  |
+
+```css
+chess-board::part(e2),
+chess-board::part(e4) {
+  box-shadow: inset 0 0 0 0.15em #f0d13a;
+}
+chess-board::part(frame) {
+  color: #666;
+}
+```
+
+Parts are per element, so highlight different squares on different boards
+with a class or id on the element as usual.
+
 ## Pieces
 
 Pieces use [Forsyth–Edwards Notation](https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation):

--- a/src/chess-board.test.ts
+++ b/src/chess-board.test.ts
@@ -311,6 +311,40 @@ describe("chess-board", () => {
     });
   });
 
+  describe("styling hooks", () => {
+    function styles(el: ChessBoardElement): string {
+      return el.shadowRoot?.querySelector("style")?.textContent ?? "";
+    }
+
+    it("exposes the board and every square as parts", () => {
+      const el = createElement(START_FEN);
+      expect(getTable(el).getAttribute("part")).toBe("board");
+      expect(getCell(el, 0, 0).getAttribute("part")).toBe("square a8 light");
+      expect(getCell(el, 4, 3).getAttribute("part")).toBe("square d4 dark");
+      expect(getCell(el, 4, 4).getAttribute("part")).toBe("square e4 light");
+      expect(getCell(el, 7, 7).getAttribute("part")).toBe("square h1 light");
+      const squares = el.shadowRoot?.querySelectorAll("[part~='square']");
+      expect(squares?.length).toBe(64);
+    });
+
+    it("exposes the frame labels as parts", () => {
+      const el = createElement(START_FEN, { frame: "" });
+      const frames = el.shadowRoot?.querySelectorAll(".frame") ?? [];
+      expect(frames.length).toBeGreaterThan(0);
+      for (const frame of frames) {
+        expect(frame.getAttribute("part")).toBe("frame");
+      }
+    });
+
+    it("reads colours and the border from custom properties", () => {
+      const css = styles(createElement());
+      expect(css).toContain("var(--chess-board-light, #FFCE9E)");
+      expect(css).toContain("var(--chess-board-dark, #D18B47)");
+      expect(css).toContain("var(--chess-board-border, 1px solid black)");
+      expect(css).toContain("var(--chess-board-frame-font-size, 40%)");
+    });
+  });
+
   describe("diffing", () => {
     it("only updates changed cells", () => {
       const el = createElement(START_FEN);

--- a/src/chess-board.ts
+++ b/src/chess-board.ts
@@ -62,7 +62,7 @@ table { border-spacing: 0; }
 :host([frame]) .frame {
   width: 1em; height: 1em;
   display: table-cell;
-  font-size: 40%;
+  font-size: var(--chess-board-frame-font-size, 40%);
 }
 :host([frame]) .frame.left,
 :host([frame]) .frame.right {
@@ -80,11 +80,11 @@ table { border-spacing: 0; }
   transform: rotate(180deg);
 }
 .chess-board {
-  border: 1px solid black;
+  border: var(--chess-board-border, 1px solid black);
   border-collapse: collapse;
 }
-.light { background: #FFCE9E; }
-.dark  { background: #D18B47; }
+.light { background: var(--chess-board-light, #FFCE9E); }
+.dark  { background: var(--chess-board-dark, #D18B47); }
 td {
   width: 1em; height: 1em;
   text-align: center;
@@ -103,43 +103,51 @@ td {
 }
 `;
 
+// The page can reach into the shadow tree with ::part(): "board" is the
+// 8x8 table, every square carries "square", its name and its shade
+// (part="square e4 light"), and the frame labels carry "frame".
 function buildBoardHTML(): string {
   let html = `<style>${STYLES}</style>`;
   html += `<table class="board-frame">`;
 
   // Top frame row
-  html += `<tr><td class="frame top left"></td>`;
-  for (const file of FILES) html += `<td class="frame top">${file}</td>`;
-  html += `<td class="frame top right"></td></tr>`;
+  html += `<tr><td class="frame top left" part="frame"></td>`;
+  for (const file of FILES) {
+    html += `<td class="frame top" part="frame">${file}</td>`;
+  }
+  html += `<td class="frame top right" part="frame"></td></tr>`;
 
   // Board rows with side frames
   for (const [ri, rank] of RANKS.entries()) {
     html += `<tr>`;
-    html += `<td class="frame left">${rank}</td>`;
+    html += `<td class="frame left" part="frame">${rank}</td>`;
 
     if (ri === 0) {
       // First rank row contains the nested chess board table
       html += `<td colspan="8" rowspan="8" class="board-wrap">`;
-      html += `<table class="chess-board">`;
+      html += `<table class="chess-board" part="board">`;
       for (const [r, boardRank] of RANKS.entries()) {
         html += `<tr>`;
         for (const [f, file] of FILES.entries()) {
           const shade = (r + f) % 2 === 0 ? "light" : "dark";
-          html += `<td class="${file}${boardRank} ${shade}"><span class="empty" data-piece=""></span></td>`;
+          const square = `${file}${boardRank}`;
+          html += `<td class="${square} ${shade}" part="square ${square} ${shade}"><span class="empty" data-piece=""></span></td>`;
         }
         html += `</tr>`;
       }
       html += `</table></td>`;
     }
 
-    html += `<td class="frame right">${rank}</td>`;
+    html += `<td class="frame right" part="frame">${rank}</td>`;
     html += `</tr>`;
   }
 
   // Bottom frame row
-  html += `<tr><td class="frame bottom left"></td>`;
-  for (const file of FILES) html += `<td class="frame bottom">${file}</td>`;
-  html += `<td class="frame bottom right"></td></tr>`;
+  html += `<tr><td class="frame bottom left" part="frame"></td>`;
+  for (const file of FILES) {
+    html += `<td class="frame bottom" part="frame">${file}</td>`;
+  }
+  html += `<td class="frame bottom right" part="frame"></td></tr>`;
 
   html += `</table>`;
   return html;


### PR DESCRIPTION
Closes #21.

Both shapes proposed in the issue, since they cost nothing together and neither touches the JavaScript API.

## Custom properties

The shadow stylesheet now reads these, with the previous hard-coded values as defaults, so nothing changes for existing pages:

| Property | Default | Applies to |
| --- | --- | --- |
| `--chess-board-light` | `#FFCE9E` | Light squares |
| `--chess-board-dark` | `#D18B47` | Dark squares |
| `--chess-board-border` | `1px solid black` | Border around the 8×8 board |
| `--chess-board-frame-font-size` | `40%` | File and rank labels |

The frame label size is included because the issue lists it among the values a page could not reach.

## Parts

- Every cell: `part="square <name> <shade>"`, e.g. `square e4 light`, so `chess-board::part(e2), chess-board::part(e4) { box-shadow: inset 0 0 0 0.15em #f0d13a }` marks a last move.
- The 8×8 table: `part="board"`.
- The file and rank labels (and the empty corner cells): `part="frame"`.

The `highlight` attribute alternative is left out: parts cover it with no JS, and an attribute can be layered on top later if it turns out to be wanted for discoverability.

## Demo

Two examples added to `index.html`, in the page's existing style: a green board with no border through the custom properties, and a board with the last move (e2, e4) marked through `::part()`. The source block under an example now includes the CSS from a `<style>` inside the example, since these two need it.

## Verification

- Three new tests check the part names on the table, on `a8`, `d4`, `e4` and `h1`, on all 64 cells and all frame cells, and that the stylesheet reads each custom property with the original default.
- Checked in headless Chromium against the built demo that `::part(e4)` overrides the square colour, the custom colours and border apply, neighbouring squares are untouched, and the generated source block shows the CSS.
- `pnpm typecheck`, `pnpm test` (30 tests), `pnpm build` and `pnpm build:pages` pass.

## Docs

`readme.md` gains a Styling section with both tables and examples. `changelog.md` gets an Unreleased entry.

Note: this PR and #24 both change the table builder in `src/chess-board.ts` and add an `Unreleased` heading to `changelog.md`, so whichever merges second needs a conflict resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VxKhiVNXdQ8Z1grVs38gY6